### PR TITLE
allow assetPrefix environment variable for use with --prefix-paths

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  assetPrefix: process.env.GATSBY_ASSET_PREFIX || "/",
   siteMetadata: {
     title: `Welcome to DigitalOcean!`,
     description: `Get your Gatsby site in 1 min`,


### PR DESCRIPTION
```
GATSBY_ASSET_PREFIX='https://westegg-sites.sfo2.digitaloceanspaces.com/westegg-frontend/live' \
gatsby build --prefix-paths && \
cd public && \
s3cmd sync --acl-public --guess-mime-type . s3://westegg-sites/westegg-frontend/live/
```